### PR TITLE
fix: handle `=` in parameters value

### DIFF
--- a/packages/core/src/manifest/params/apply-params.test.ts
+++ b/packages/core/src/manifest/params/apply-params.test.ts
@@ -40,3 +40,23 @@ test("correctly handle '=' in parameters value", async () => {
   assert.equal(module.name, "mymodule");
   assert.equal((input.input.value as Module_Input_Params).value, "A=B=C");
 });
+
+test("correctly handle empty parameters value", async () => {
+  const input = new Module_Input({
+    input: {
+      case: "params",
+      value: {
+        value: "",
+      },
+    },
+  });
+
+  const module = new Module({
+    name: "mymodule",
+    inputs: [input],
+  });
+
+  applyParams(["mymodule="], [module]);
+  assert.equal(module.name, "mymodule");
+  assert.equal((input.input.value as Module_Input_Params).value, "");
+});

--- a/packages/core/src/manifest/params/apply-params.test.ts
+++ b/packages/core/src/manifest/params/apply-params.test.ts
@@ -20,3 +20,23 @@ test("correctly injects parameters into a module", async () => {
   applyParams(["a=foo"], [module]);
   assert.equal((input.input.value as Module_Input_Params).value, "foo");
 });
+
+test("correctly handle '=' in parameters value", async () => {
+  const input = new Module_Input({
+    input: {
+      case: "params",
+      value: {
+        value: "",
+      },
+    },
+  });
+
+  const module = new Module({
+    name: "mymodule",
+    inputs: [input],
+  });
+
+  applyParams(["mymodule=A=B=C"], [module]);
+  assert.equal(module.name, "mymodule");
+  assert.equal((input.input.value as Module_Input_Params).value, "A=B=C");
+});

--- a/packages/core/src/manifest/params/apply-params.ts
+++ b/packages/core/src/manifest/params/apply-params.ts
@@ -3,7 +3,7 @@ import { getModuleOrThrow } from "../../utils/get-module.js";
 
 export function applyParams(params: string[], modules: Module[]) {
   for (const param of params) {
-    const [module, value] = param.split("=", 2);
+    const [module, value] = param.split(/=(.*)/s);
     if (module === undefined || value === undefined) {
       throw new Error(`Invalid param ${param}. Must be in the form of "module=value" or "imported:module=value"`);
     }

--- a/packages/core/src/manifest/params/apply-params.ts
+++ b/packages/core/src/manifest/params/apply-params.ts
@@ -3,10 +3,13 @@ import { getModuleOrThrow } from "../../utils/get-module.js";
 
 export function applyParams(params: string[], modules: Module[]) {
   for (const param of params) {
-    const [module, value] = param.split(/=(.*)/s);
-    if (module === undefined || value === undefined) {
+    const index = param.indexOf("=");
+    if (index <= 0) {
       throw new Error(`Invalid param ${param}. Must be in the form of "module=value" or "imported:module=value"`);
     }
+
+    const module = param.slice(0, index);
+    const value = param.slice(index + 1);
 
     const match = getModuleOrThrow(modules, module);
     const [input] = match.inputs;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of parameters in the `applyParams` function.

### Detailed summary:
- Added a check to ensure that the parameter contains an "=" sign.
- Split the parameter into module and value based on the "=" sign.
- Updated tests to handle parameters with "=" sign and empty values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->