### PR TITLE
hotfix for protofiles that are disordered

### DIFF
--- a/packages/core/src/utils/create-registry.ts
+++ b/packages/core/src/utils/create-registry.ts
@@ -2,5 +2,21 @@ import { type IMessageTypeRegistry, createDescriptorSet, createRegistryFromDescr
 import type { Package } from "../proto.js";
 
 export function createRegistry(substream: Package): IMessageTypeRegistry {
+  let reordered = [];
+    for (let i = 0; i < substream.protoFiles.length; i++) {
+        let file = substream.protoFiles[i];
+        if (file.name === "google/protobuf/any.proto") {
+            reordered.push(file);
+            break;
+        }
+    }
+    for (let i = 0; i < substream.protoFiles.length; i++) {
+        let file = substream.protoFiles[i];
+        if (file.name === "google/protobuf/any.proto") {
+            continue;
+        }
+        reordered.push(file);
+    }
+
   return createRegistryFromDescriptors(createDescriptorSet(substream.protoFiles), true);
 }


### PR DESCRIPTION
It seems the ordering of the proto descriptors in the `.spkg` is important for `createRegistry`.